### PR TITLE
port-dev: Add sysutils/auto-admin to run depends

### DIFF
--- a/port-dev/Makefile
+++ b/port-dev/Makefile
@@ -11,7 +11,8 @@ COMMENT=	Tools for port development
 LICENSE=	BSD3CLAUSE
 
 RUN_DEPENDS=	portlint:ports-mgmt/portlint \
-		port:ports-mgmt/porttools
+		port:ports-mgmt/porttools \
+		auto-admin:sysutils/auto-admin
 
 USES+=		tar:xz
 


### PR DESCRIPTION
Used in port-poudriere-setup & port-poudriere-test; possibly others.